### PR TITLE
郵便番号関係の実装

### DIFF
--- a/backend/app/Console/Commands/ImportPostalCodeCommand.php
+++ b/backend/app/Console/Commands/ImportPostalCodeCommand.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class ImportPostalCodeCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'import:postal_code';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Import postal-code';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        \App\PostalCode::truncate();
+        // CSVファイルの文字コード変換
+        $csv_path = storage_path('app/csv/KEN_ALL.CSV');
+        $converted_csv_path = storage_path('app/csv/postal_code_utf8.csv');
+        file_put_contents(
+            $converted_csv_path,
+            mb_convert_encoding(
+                file_get_contents($csv_path),
+                'UTF-8',
+                'SJIS-win'
+            )
+        );
+
+        // CSVから郵便データを取得してDBへ保存
+        $file = new \SplFileObject($converted_csv_path);
+        $file->setFlags(\SplFileObject::READ_CSV);
+
+        foreach ($file as $row) {
+
+            if (!is_null($row[0])) {
+
+                \App\PostalCode::create([
+                    'first_code' => intval(substr($row[2], 0, 3)),
+                    'last_code' => intval(substr($row[2], 3, 4)),
+                    'prefecture' => $row[6],
+                    'city' => $row[7],
+                    'address' => (str_contains($row[8], '（')) ? current(explode('（', $row[8])) : $row[8]
+                ]);
+            }
+        }
+    }
+}

--- a/backend/app/Http/Controllers/LocationController.php
+++ b/backend/app/Http/Controllers/LocationController.php
@@ -11,6 +11,8 @@ use App\User;
 use \Datetime;
 use \DateTimeZone;
 use Illuminate\Support\Facades\Auth;
+use Validator;
+
 
 class LocationController extends Controller
 {
@@ -32,7 +34,8 @@ class LocationController extends Controller
         $last_code   = intval(substr($zipcode, 3));
         $a = PostalCode::whereSearch($first_code, $last_code)->first();
         if ($a === null) {
-            return redirect('locations/create')->withInput();
+            $error[] = "この郵便番号は実在しません";
+            return redirect('locations/create')->withInput()->withErrors($error);
         } else {
             $location->save();
             return redirect()->route("users.show", ["name" => $request->user()->name]);

--- a/backend/app/Http/Controllers/LocationController.php
+++ b/backend/app/Http/Controllers/LocationController.php
@@ -6,6 +6,7 @@ use App\Http\Requests\LocationRequest as RequestsLocationRequest;
 use Illuminate\Http\Request;
 use App\http\Requests\LocationRequest;
 use App\Location;
+use App\PostalCode;
 use App\User;
 use \Datetime;
 use \DateTimeZone;
@@ -26,8 +27,16 @@ class LocationController extends Controller
     {
         $location->fill($request->all());
         $location->user_id = $request->user()->id;
-        $location->save();
-        return redirect()->route("users.show", ["name" => $request->user()->name]);
+        $zipcode = $location->zipcode;
+        $first_code   = intval(substr($zipcode, 0, 3));
+        $last_code   = intval(substr($zipcode, 3));
+        $a = PostalCode::whereSearch($first_code, $last_code)->first();
+        if ($a === null) {
+            return redirect('locations/create')->withInput();
+        } else {
+            $location->save();
+            return redirect()->route("users.show", ["name" => $request->user()->name]);
+        }
     }
 
     public function edit(Location $location)

--- a/backend/app/Http/Controllers/LocationController.php
+++ b/backend/app/Http/Controllers/LocationController.php
@@ -25,9 +25,12 @@ class LocationController extends Controller
     {
         return view("locations/create");
     }
-    public function store(LocationRequest $request, Location $location)
+    public function store(LocationRequest $request)
     {
+        $location = new Location();
         $location->fill($request->all());
+        $location->zipcode = $request->zipcode;
+        $location->address = $request->addr11;
         $location->user_id = $request->user()->id;
         $zipcode = $location->zipcode;
         $first_code   = intval(substr($zipcode, 0, 3));
@@ -37,6 +40,7 @@ class LocationController extends Controller
             $error[] = "この郵便番号は実在しません";
             return redirect('locations/create')->withInput()->withErrors($error);
         } else {
+
             $location->save();
             return redirect()->route("users.show", ["name" => $request->user()->name]);
         }
@@ -48,8 +52,23 @@ class LocationController extends Controller
     }
     public function update(Request $request, Location $location)
     {
-        $location->fill($request->all())->save();
-        return redirect()->route("users.show", ["name" => $request->user()->name]);
+
+        $location->fill($request->all());
+        $location->zipcode = $request->zipcode;
+        $location->address = $request->addr11;
+        $location->user_id = $request->user()->id;
+        $zipcode = $location->zipcode;
+        $first_code   = intval(substr($zipcode, 0, 3));
+        $last_code   = intval(substr($zipcode, 3));
+        $a = PostalCode::whereSearch($first_code, $last_code)->first();
+        if ($a === null) {
+            $error[] = "この郵便番号は実在しません";
+            return redirect('locations/create')->withInput()->withErrors($error);
+        } else {
+
+            $location->fill($request->all())->save();
+            return redirect()->route("users.show", ["name" => $request->user()->name]);
+        }
     }
     public function destroy(Request $request, Location $location)
     {

--- a/backend/app/Http/Controllers/PostalCodeController.php
+++ b/backend/app/Http/Controllers/PostalCodeController.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class PostalCodeController extends Controller
+{
+}

--- a/backend/app/Http/Requests/LocationRequest.php
+++ b/backend/app/Http/Requests/LocationRequest.php
@@ -28,6 +28,9 @@ class LocationRequest extends FormRequest
                 "required",
                 'digits:7'
             ],
+            "addr11" => [
+                "required"
+            ],
 
         ];
     }
@@ -35,6 +38,8 @@ class LocationRequest extends FormRequest
     {
         return [
             "zipcode" => "郵便番号",
+            "address" => "位置情報",
+            "addr11" => "位置情報",
         ];
     }
 }

--- a/backend/app/Location.php
+++ b/backend/app/Location.php
@@ -9,6 +9,7 @@ class Location extends Model
 {
     public $fillable = [
         "zipcode",
+        "address",
     ];
     public function user(): BelongsTo
     {

--- a/backend/app/PostalCode.php
+++ b/backend/app/PostalCode.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PostalCode extends Model
+{
+    public $timestamps = false;
+    protected $guarded = ["id"];
+
+
+    // scope
+    public function scopeWhereSearch($query, $first_code, $last_code)
+    {
+        $query->where("first_code", intval($first_code))->where("last_code", $last_code);
+    }
+    // Accessor
+    public function getFirstCodeAttribute($value)
+    {
+        return str_pad($value, 3, "0", STR_PAD_LEFT);
+    }
+    public function getLastCodeAttribute($value)
+    {
+
+        return str_pad($value, 4, '0', STR_PAD_LEFT);
+    }
+}

--- a/backend/database/migrations/2021_03_15_160015_create_postal_codes_table.php
+++ b/backend/database/migrations/2021_03_15_160015_create_postal_codes_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePostalCodesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('postal_codes', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('first_code')->index();
+            $table->unsignedInteger('last_code')->index();
+            $table->string('prefecture');
+            $table->string('city');
+            $table->string('address');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('postal_codes');
+    }
+}

--- a/backend/database/migrations/2021_03_16_100848_add_address_to_location_table.php
+++ b/backend/database/migrations/2021_03_16_100848_add_address_to_location_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddAddressToLocationTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('locations', function (Blueprint $table) {
+            $table->string('address');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('locations', function (Blueprint $table) {
+            //
+        });
+    }
+}

--- a/backend/resources/views/app.blade.php
+++ b/backend/resources/views/app.blade.php
@@ -13,6 +13,7 @@
   <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.3.1/css/bootstrap.min.css" rel="stylesheet">
   <!-- Material Design Bootstrap -->
   <link href="https://cdnjs.cloudflare.com/ajax/libs/mdbootstrap/4.8.11/css/mdb.min.css" rel="stylesheet">
+  <script src="https://ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
 </head>
 
 <body>

--- a/backend/resources/views/error_card_list.blade.php
+++ b/backend/resources/views/error_card_list.blade.php
@@ -1,0 +1,9 @@
+@if ($errors->any())
+  <div class="card-text text-left alert alert-danger">
+    <ul class="mb-0">
+      @foreach($errors->all() as $error)
+        <li>{{ $error }}</li>
+      @endforeach
+    </ul>
+  </div>
+@endif

--- a/backend/resources/views/locations/create.blade.php
+++ b/backend/resources/views/locations/create.blade.php
@@ -8,7 +8,15 @@
       <div class="col-12">
         <div class="card mt-3">
           <div class="card-body pt-0">
-            {{-- @include('error_card_list') --}}
+            @include('error_card_list')
+            {{-- @if ($msg ?? '')
+              <div class="card-text text-left alert alert-danger">
+              <ul class="mb-0">
+                  <li>{{$msg ?? ''}}</li>
+              </ul>
+              </div>  
+            @endif
+     --}}
             <div class="card-text">
               <form method="POST" action="{{ route('locations.store') }}">
                 @csrf

--- a/backend/resources/views/locations/create.blade.php
+++ b/backend/resources/views/locations/create.blade.php
@@ -14,7 +14,7 @@
                 @csrf
                 <div class="md-form">
                   <label>天気を知りたい場所の郵便番号(ハイフンなし)を入力</label>
-                  <input type="text" name="zipcode" class="form-control" required value="{{ $location->zipcode ?? old('zipocode') }}">
+                  <input type="text" name="zipcode" class="form-control" required value="{{ $location->zipcode ?? old('zipcode') }}">
                 </div>
                 <button type="submit" class="btn blue-gradient btn-block">登録する</button>
               </form>

--- a/backend/resources/views/locations/create.blade.php
+++ b/backend/resources/views/locations/create.blade.php
@@ -9,20 +9,17 @@
         <div class="card mt-3">
           <div class="card-body pt-0">
             @include('error_card_list')
-            {{-- @if ($msg ?? '')
-              <div class="card-text text-left alert alert-danger">
-              <ul class="mb-0">
-                  <li>{{$msg ?? ''}}</li>
-              </ul>
-              </div>  
-            @endif
-     --}}
+
             <div class="card-text">
               <form method="POST" action="{{ route('locations.store') }}">
                 @csrf
                 <div class="md-form">
                   <label>天気を知りたい場所の郵便番号(ハイフンなし)を入力</label>
-                  <input type="text" name="zipcode" class="form-control" required value="{{ $location->zipcode ?? old('zipcode') }}">
+                  <input type="text" name="zipcode" class="form-control" required value="{{ $location->zipcode ?? old('zipcode') }}" onKeyUp="AjaxZip3.zip2addr(this,'','addr11','addr11')";>
+                </div>
+                  <div class="md-form">
+                  <label>位置情報（自動入力）</label>
+                  <input type="text" name="addr11" class="form-control" readonly required value="{{ $location->address ?? old('address') }}">
                 </div>
                 <button type="submit" class="btn blue-gradient btn-block">登録する</button>
               </form>

--- a/backend/resources/views/locations/edit.blade.php
+++ b/backend/resources/views/locations/edit.blade.php
@@ -8,15 +8,18 @@
       <div class="col-12">
         <div class="card mt-3">
           <div class="card-body pt-0">
-            {{-- @include('error_card_list') --}}
+            @include('error_card_list')
             <div class="card-text">
-              <form method="POST" action="{{ route('locations.update',["location"=> $location ]) }}">
+                <form method="POST" action="{{ route('locations.update',["location"=> $location ]) }}">
                 @method("PATCH")
                 @csrf
-
                 <div class="md-form">
                   <label>天気を知りたい場所の郵便番号(ハイフンなし)を入力</label>
-                  <input type="text" name="zipcode" class="form-control" required value="{{ $location->zipcode ?? old('zipcode') }}">
+                  <input type="text" name="zipcode" class="form-control" required value="{{ $location->zipcode ?? old('zipcode') }}" onKeyUp="AjaxZip3.zip2addr(this,'','addr11','addr11')";>
+                </div>
+                  <div class="md-form">
+                  <label>位置情報（自動入力）</label>
+                  <input type="text" name="addr11" class="form-control" readonly required value="{{ $location->address ?? old('address') }}">
                 </div>
                 <button type="submit" class="btn blue-gradient btn-block">変更する</button>
               </form>

--- a/backend/resources/views/locations/show.blade.php
+++ b/backend/resources/views/locations/show.blade.php
@@ -32,7 +32,7 @@
               <i class="fas fa-pen mr-1"></i>位置情報を更新する
             </a>
             <div class="dropdown-divider"></div>
-            <a class="dropdown-item text-danger" data-toggle="modal" data-target="#modal-delete-{{ $location }}">
+            <a class="dropdown-item text-danger" data-toggle="modal" data-target="#modal-delete-{{$location->id}}">
               <i class="fas fa-trash-alt mr-1"></i>位置情報を削除する
             </a>
           </div>

--- a/backend/resources/views/locations/show.blade.php
+++ b/backend/resources/views/locations/show.blade.php
@@ -10,12 +10,12 @@
       <i class="far fa-question-circle fa-3x mr-1"></i>
       <div>
         <div class="font-weight-bold">
-  郵便番号：  {{$location->zipcode}}
+          郵便番号：  {{$location->zipcode}}
         </div> 
         <div class="font-weight-lighter">
-                  <h1 class="h3 card-title ">
-        {{$tomorrow}}の天気
-      </h1>
+        <h1 class="h4 card-title ">
+          {{$location->address}}の {{$tomorrow}}の天気
+        </h1>
         </div>
       </div>
     @if( Auth::id() === $location->user_id )

--- a/backend/resources/views/users/show.blade.php
+++ b/backend/resources/views/users/show.blade.php
@@ -16,6 +16,9 @@
       <div class="font-weight-bold">
         郵便番号：  {{$location->zipcode}}
      </div> 
+      <div class="font-weight-bold">
+        位置情報：  {{$location->address}}
+     </div> 
 
       </a> 
       </div>

--- a/backend/resources/views/users/show.blade.php
+++ b/backend/resources/views/users/show.blade.php
@@ -33,7 +33,7 @@
               <i class="fas fa-pen mr-1"></i>位置情報を更新する
             </a>
             <div class="dropdown-divider"></div>
-            <a class="dropdown-item text-danger" data-toggle="modal" data-target="#modal-delete-{{ $location }}">
+            <a class="dropdown-item text-danger" data-toggle="modal" data-target="#modal-delete-{{ $location->id }}">
               <i class="fas fa-trash-alt mr-1"></i>位置情報を削除する
             </a>
           </div>


### PR DESCRIPTION
# 実装内容
- 位置情報削除できないバグ修正
- PostalCodeテーブルを作成
- 実在しない郵便番号は登録できないバリテーション、エラー文実装
- 位置情報カラムの追加
-郵便番号から自動入力実装（http://www.webdesign-fan.com/ajaxzip3）
- 位置情報のCRUD機能追加